### PR TITLE
white-space:nowrap

### DIFF
--- a/System/Console/CmdArgs/Text.hs
+++ b/System/Console/CmdArgs/Text.hs
@@ -138,9 +138,13 @@ showHTML xs = unlines $
 
         tr x = "<tr>" ++ x ++ "</tr>"
         td cols x = "<td" ++ (if cols == 1 then "" else " colspan='" ++ show cols ++ "'")
-                          ++ (if a /= "" then " style='padding-left:" ++ show (length a) ++ "ex;'" else "") ++
+                          ++ (if null styles then "" else " style='" ++ unwords styles ++ "'") ++
                      ">" ++ if null b then "&nbsp;" else concatMap esc b ++ "</td>"
             where (a,b) = span isSpace x
+                  -- if the first letter of the contents is '-', assume this is a flag
+                  isFlag = take 1 b == "-"
+                  styles = [ "padding-left:" ++ show (length a) ++ "ex;" | a /= "" ]
+                        ++ [ "white-space:nowrap;" | isFlag ]
 
         esc '&' = "&amp;"
         esc '>' = "&gt;"

--- a/System/Console/CmdArgs/Text.hs
+++ b/System/Console/CmdArgs/Text.hs
@@ -131,10 +131,10 @@ showHTML xs = unlines $
     map f xs ++
     ["</table>"]
     where
-        cols = maximum [length x | Cols x <- xs]
+        maxCols = maximum [length x | Cols x <- xs]
 
-        f (Line x) = tr $ td cols x
-        f (Cols xs) = tr $ concatMap (td 1) (init xs) ++ td (cols + 1 - length xs) (last xs)
+        f (Line x) = tr $ td maxCols x
+        f (Cols xs) = tr $ concatMap (td 1) (init xs) ++ td (maxCols + 1 - length xs) (last xs)
 
         tr x = "<tr>" ++ x ++ "</tr>"
         td cols x = "<td" ++ (if cols == 1 then "" else " colspan='" ++ show cols ++ "'")


### PR DESCRIPTION
Using style="white-space:nowrap;" for flags, so they do not get broken into multiple lines.

For example, I had html output where "-o" was being broken into multiple lines. That doesn't look good at all.

I am checking the first non-whitespace character of the contents of the td tag to detect flags. If the first character is '-', it is assumed to be a flag. I am not sure if this is the best way of implementing this, but it seems to work good enough.