### PR TITLE
preserve newlines in the html output too

### DIFF
--- a/System/Console/CmdArgs/Text.hs
+++ b/System/Console/CmdArgs/Text.hs
@@ -150,4 +150,5 @@ showHTML xs = unlines $
         esc '&' = "&amp;"
         esc '>' = "&gt;"
         esc '<' = "&lt;"
+        esc '\n' = "<br />"
         esc x = [x]


### PR DESCRIPTION
This was much simpler, now that the newline characters are preserved in the string.