### PR TITLE
Fix the GHC 8.2 build

### DIFF
--- a/Data/Generics/Any.hs
+++ b/Data/Generics/Any.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Data.Generics.Any where
@@ -8,7 +9,11 @@ import qualified Data.Data as D
 import Data.Data hiding (toConstr, typeOf, dataTypeOf, isAlgType)
 import Data.List
 import Data.Maybe
+#if MIN_VERSION_base(4,5,0)
+import qualified Data.Typeable as I
+#else
 import qualified Data.Typeable.Internal as I
+#endif
 import System.IO.Unsafe
 
 


### PR DESCRIPTION
The `Data.Typeable.Internal` module was removed in `base-4.10`/GHC 8.2. Luckily, `cmdargs` only imports it for access to `tyConName`, a function which has been a part of the public `Data.Typeable` interface for a while, so this can be fixed with some minimal CPP.